### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require("path"),
-	gutil = require("gulp-util"),
+	PluginError = require('plugin-error'),
+	Vinyl = require('vinyl'),
 	through = require("through2"),
 	customizr = require("customizr");
 
@@ -49,7 +50,7 @@ module.exports = function (fileName, opt) {
 
 		// No stream support (yet?)
 		if (file.isStream()) {
-			stream.emit("error", new gutil.PluginError({
+			stream.emit("error", new PluginError({
 				plugin: PLUGIN_NAME,
 				message: "Streaming not supported"
 			}));
@@ -78,14 +79,14 @@ module.exports = function (fileName, opt) {
 
 			// Sanity check
 			if (!data.result) {
-				return stream.emit("error", new gutil.PluginError({
+				return stream.emit("error", new PluginError({
 					plugin: PLUGIN_NAME,
 					message: "No data returned"
 				}));
 			}
 
 			// Save result
-			var file = new gutil.File({
+			var file = new Vinyl({
 				path: path.join(firstFile.base, fileName),
 				base: firstFile.base,
 				cwd: firstFile.cwd,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "customizr": "^1.0.0-alpha",
     "grunt-legacy-log": "~0.1.1",
     "plugin-error": "^0.1.2",
-    "through2": "~0.4.0",
+    "through2": "^2.0.3",
     "vinyl": "^2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
   "dependencies": {
     "customizr": "^1.0.0-alpha",
     "grunt-legacy-log": "~0.1.1",
-    "gulp-util": "~2.2.10",
-    "through2": "~0.4.0"
+    "plugin-error": "^0.1.2",
+    "through2": "~0.4.0",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
-    "event-stream": "~3.1.0",
     "assert": "~1.1.0",
-    "mocha": "~1.17.0",
-    "gulp": "~3.5.1"
+    "event-stream": "~3.1.0",
+    "gulp": "~3.5.1",
+    "mocha": "~1.17.0"
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,7 +2,7 @@
 
 var fs = require("fs"),
 	assert = require("assert"),
-	gutil = require("gulp-util"),
+	Vinyl =require('vinyl'),
 	modernizr = require("../");
 
 describe("gulp-modernizr", function () {
@@ -20,7 +20,7 @@ describe("gulp-modernizr", function () {
 				done();
 			});
 
-			stream.write(new gutil.File({
+			stream.write(new Vinyl({
 				path: TEST_PATH,
 				contents: fs.readFileSync(TEST_PATH)
 			}));


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, **it is important to replace `gulp-util`**.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.